### PR TITLE
add finish report email

### DIFF
--- a/yearbook_ccs/apps/comment/templates/profile_comment.html
+++ b/yearbook_ccs/apps/comment/templates/profile_comment.html
@@ -54,12 +54,13 @@
     </form>
     {% endif %} {% if request.user == comment.author %}
     <button class="btn-edit-comment" value="{{ comment.id }}">· Edit</button>
+    {% elif not request.user.is_superuser %}
     <button
       name="post_id"
       value="{{comment.id}}"
       class="reportBtn comment_report"
     >
-      Report
+      · Report
     </button>
     {% endif %}
   </div>

--- a/yearbook_ccs/apps/report/templates/component/report_finish_email.html
+++ b/yearbook_ccs/apps/report/templates/component/report_finish_email.html
@@ -1,0 +1,13 @@
+{% autoescape off %}
+<pre>
+  Dear <b>{{ username }}</b>,
+
+  Your report on a {{ reported_content }} for "{{ report_reason }}" has been finished. 
+  Please review the action taken by the admins below:
+  
+  <em>{{ report_action }}</em>
+  
+  Regards,
+  CCS Yearbook-esque Admin
+</pre>
+{% endautoescape %}

--- a/yearbook_ccs/static/css/messages.css
+++ b/yearbook_ccs/static/css/messages.css
@@ -6,7 +6,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  animation: fadeOut 3s forwards;
+  animation: fadeOut 2s forwards;
 }
 
 @keyframes fadeOut {


### PR DESCRIPTION
users who reported a blog, comment, or profile will now receive emails whenever an admin closes the report.